### PR TITLE
Fix bug in STRspy_setup.sh

### DIFF
--- a/setup/STRspy_setup.sh
+++ b/setup/STRspy_setup.sh
@@ -84,7 +84,7 @@ if hash conda >/dev/null 2>&1; then
 	source ~/.bashrc
 	source ~/.bash_profile
 	echo -e "#Installation done"
-	exit 1;
+	exit 0;
 else
 	clear
 	echo -e "#conda/miniconda appears to have NOT installed ! please install it to continue.."


### PR DESCRIPTION
After successful installation, the current script returns exit code 1, which implies an error. This can create problems. For example, when installing strspy from a Dockerfile, it breaks the installation process after the exit code 1 is returned. Successful installation now returns exit code 0 which implies success.