### PR TITLE
Fix Bug 1: wrapper script filename mismatch and GenerateToolConfig output path

### DIFF
--- a/STRspy_run_v2.0_Args.sh
+++ b/STRspy_run_v2.0_Args.sh
@@ -177,7 +177,7 @@ echo -e "#PARALLEL 			:" $PARALLEL
 ########################
 
 if [[ $ParallelJob == "parallel" ]] || [[ $ParallelJob == "Parallel" ]] || [[ $ParallelJob == "PARALLEL" ]] ; then
-	if [[ -f "STRspy_Parallel_v1.1_Args.sh" ]]; then
+	if [[ -f "src/STRspy_Parallel_v2.0_Args.sh" ]]; then
 		echo -e "\n"
 		echo -e "\t\t  ~ ~ ~ ~ Running STRspy ~ ~ ~ ~	 "
 		echo -e "\t\tAnalysis date:" `date`
@@ -190,7 +190,7 @@ if [[ $ParallelJob == "parallel" ]] || [[ $ParallelJob == "Parallel" ]] || [[ $P
 		exit 1;
 	fi
 else
-	if [[ -f "STRspy_Normal_v1.1_Args.sh" ]]; then
+	if [[ -f "src/STRspy_Normal_v2.0_Args.sh" ]]; then
 		echo -e "\n"
 		echo -e "\t\t  ~ ~ ~ ~ Running STRspy ~ ~ ~ ~	 "
 		echo -e "\t\tAnalysis date:" `date`

--- a/setup/GenerateToolConfig.sh
+++ b/setup/GenerateToolConfig.sh
@@ -4,17 +4,17 @@
 #echo -e "This will create a ToolConfig file to run STRspy..."
 
 SAMTOOLS=$(which samtools)
-echo -e "SAMTOOLS="$SAMTOOLS > UserToolsConfig.txt
+echo -e "SAMTOOLS="$SAMTOOLS > config/UserToolsConfig.txt
 BEDTOOLS=$(which bedtools)
-echo -e "BEDTOOLS="$BEDTOOLS >> UserToolsConfig.txt
+echo -e "BEDTOOLS="$BEDTOOLS >> config/UserToolsConfig.txt
 XATLAS=$(which xatlas)
-echo -e "XATLAS="$XATLAS >> UserToolsConfig.txt
+echo -e "XATLAS="$XATLAS >> config/UserToolsConfig.txt
 PARALLEL=$(which parallel)
-echo -e "PARALLEL="$PARALLEL >> UserToolsConfig.txt
+echo -e "PARALLEL="$PARALLEL >> config/UserToolsConfig.txt
 MINIMAP=$(which minimap2)
-echo -e "MINIMAP="$MINIMAP >> UserToolsConfig.txt
+echo -e "MINIMAP="$MINIMAP >> config/UserToolsConfig.txt
 SEQKIT=$(which seqkit)
-echo -e "SEQKIT="$SEQKIT >> UserToolsConfig.txt
+echo -e "SEQKIT="$SEQKIT >> config/UserToolsConfig.txt
 
 echo -e "ToolConfig file is generated."
 


### PR DESCRIPTION
## Fixes

### Bug 1 - STRspy_run_v2.0_Args.sh
The wrapper was checking for `STRspy_Normal_v1.1_Args.sh` and 
`STRspy_Parallel_v1.1_Args.sh` in the root directory, but the actual 
files are named `v2.0` and located in `src/`. This caused the wrapper 
to always exit with "please make sure you are in the same directory of 
STRspy" even when run correctly.

Fixed by updating the checks to `src/STRspy_Normal_v2.0_Args.sh` and 
`src/STRspy_Parallel_v2.0_Args.sh`.

### GenerateToolConfig.sh
The script was writing `UserToolsConfig.txt` to the current directory 
instead of `config/`. Fixed output path to write directly to 
`config/UserToolsConfig.txt`.

## Tested
Validated on Ubuntu 22.04, conda strspy_env, ONT R10 BAM input, GRCh38.
Successfully genotyped 52 loci end-to-end.

Relates to issue #12.